### PR TITLE
Add advanced filters to capacitacao list

### DIFF
--- a/src/main/webapp/app/entities/capacitacao/list/capacitacao.component.html
+++ b/src/main/webapp/app/entities/capacitacao/list/capacitacao.component.html
@@ -61,6 +61,51 @@
     </div>
   </form>
 
+  <div class="mt-2">
+    <button class="btn btn-secondary" (click)="showAdvanced = !showAdvanced">Filtros Avançados</button>
+  </div>
+
+  <div class="card card-body mt-2" *ngIf="showAdvanced">
+    <form class="row g-2">
+      <div class="col-md-3">
+        <input type="text" class="form-control" [(ngModel)]="advancedFilters.nomeGuerra" name="nomeGuerra" placeholder="Nome de Guerra" />
+      </div>
+      <div class="col-md-2">
+        <input type="text" class="form-control" [(ngModel)]="advancedFilters.posto" name="posto" placeholder="Posto" />
+      </div>
+      <div class="col-md-2">
+        <input type="text" class="form-control" [(ngModel)]="advancedFilters.om" name="om" placeholder="OM" />
+      </div>
+      <div class="col-md-2">
+        <input type="text" class="form-control" [(ngModel)]="advancedFilters.cursoSigla" name="cursoSigla" placeholder="Sigla do Curso" />
+      </div>
+      <div class="col-md-2">
+        <input type="number" class="form-control" [(ngModel)]="advancedFilters.ano" name="ano" placeholder="Ano" />
+      </div>
+      <div class="col-md-2">
+        <input type="text" class="form-control" [(ngModel)]="advancedFilters.turma" name="turma" placeholder="Turma" />
+      </div>
+      <div class="col-md-3">
+        <select class="form-select" [(ngModel)]="advancedFilters.capacitacaoStatus" name="capacitacaoStatus">
+          <option value="">Status da Capacitação</option>
+          @for (s of statusEnumValues; track s) {
+            <option [value]="s">{{ 'ecursosApp.StatusEnum.' + s | translate }}</option>
+          }
+        </select>
+      </div>
+      <div class="col-md-3">
+        <input type="date" class="form-control" [(ngModel)]="advancedFilters.inicio" name="inicio" />
+      </div>
+      <div class="col-md-3">
+        <input type="date" class="form-control" [(ngModel)]="advancedFilters.termino" name="termino" />
+      </div>
+      <div class="col-12">
+        <button type="button" class="btn btn-primary me-2" (click)="applyAdvancedFilters()">Filtrar</button>
+        <button type="button" class="btn btn-outline-secondary" (click)="clearAdvancedFilters()">Limpar</button>
+      </div>
+    </form>
+  </div>
+
   <jhi-filter [filters]="filters"></jhi-filter>
 
   @if (capacitacaos?.length === 0) {


### PR DESCRIPTION
## Summary
- enable advanced filter panel in Capacitacao list
- allow filtering by several fields at once

## Testing
- `npm run lint` *(fails: Cannot find package 'globals')*
- `npm test` *(fails: Cannot find package 'globals')*

------
https://chatgpt.com/codex/tasks/task_e_68536a798358832b8914ec5a899619bb