### PR TITLE
Improve advanced filter options

### DIFF
--- a/src/main/webapp/app/entities/capacitacao/list/capacitacao.component.html
+++ b/src/main/webapp/app/entities/capacitacao/list/capacitacao.component.html
@@ -68,22 +68,42 @@
   <div class="card card-body mt-2" *ngIf="showAdvanced">
     <form class="row g-2">
       <div class="col-md-3">
-        <input type="text" class="form-control" [(ngModel)]="advancedFilters.nomeGuerra" name="nomeGuerra" placeholder="Nome de Guerra" />
+        <select class="form-select" [(ngModel)]="advancedFilters.nomeGuerra" name="nomeGuerra">
+          <option value="">Nome de Guerra</option>
+          @for (n of nomeGuerraOptions; track n) {
+            <option [value]="n">{{ n }}</option>
+          }
+        </select>
       </div>
       <div class="col-md-2">
-        <input type="text" class="form-control" [(ngModel)]="advancedFilters.posto" name="posto" placeholder="Posto" />
+        <select class="form-select" [(ngModel)]="advancedFilters.posto" name="posto">
+          <option value="">Posto</option>
+          @for (p of postoOptions; track p) {
+            <option [value]="p">{{ p }}</option>
+          }
+        </select>
       </div>
       <div class="col-md-2">
         <input type="text" class="form-control" [(ngModel)]="advancedFilters.om" name="om" placeholder="OM" />
       </div>
       <div class="col-md-2">
-        <input type="text" class="form-control" [(ngModel)]="advancedFilters.cursoSigla" name="cursoSigla" placeholder="Sigla do Curso" />
+        <select class="form-select" [(ngModel)]="advancedFilters.cursoSigla" name="cursoSigla">
+          <option value="">Sigla do Curso</option>
+          @for (c of cursoSiglaOptions; track c) {
+            <option [value]="c">{{ c }}</option>
+          }
+        </select>
       </div>
       <div class="col-md-2">
         <input type="number" class="form-control" [(ngModel)]="advancedFilters.ano" name="ano" placeholder="Ano" />
       </div>
       <div class="col-md-2">
-        <input type="text" class="form-control" [(ngModel)]="advancedFilters.turma" name="turma" placeholder="Turma" />
+        <select class="form-select" [(ngModel)]="advancedFilters.turma" name="turma">
+          <option value="">Turma</option>
+          @for (t of turmaOptions; track t) {
+            <option [value]="t">{{ t }}</option>
+          }
+        </select>
       </div>
       <div class="col-md-3">
         <select class="form-select" [(ngModel)]="advancedFilters.capacitacaoStatus" name="capacitacaoStatus">

--- a/src/main/webapp/app/entities/capacitacao/list/capacitacao.component.ts
+++ b/src/main/webapp/app/entities/capacitacao/list/capacitacao.component.ts
@@ -53,6 +53,10 @@ export class CapacitacaoComponent implements OnInit {
   statusEnumValues = Object.keys(StatusEnum);
   showAdvanced = false;
   allCapacitacaos: ICapacitacao[] = [];
+  nomeGuerraOptions: string[] = [];
+  postoOptions: string[] = [];
+  cursoSiglaOptions: string[] = [];
+  turmaOptions: string[] = [];
   advancedFilters: any = {
     nomeGuerra: '',
     posto: '',
@@ -268,7 +272,37 @@ export class CapacitacaoComponent implements OnInit {
   loadAllCapacitacaos(): void {
     this.capacitacaoService.queryAll({ eagerload: true }).subscribe(res => {
       this.allCapacitacaos = res.body ?? [];
+      this.updateFilterOptions();
+      this.capacitacaos = this.allCapacitacaos.slice();
+      this.totalItems = this.capacitacaos.length;
     });
+  }
+
+  updateFilterOptions(): void {
+    const nomeSet = new Set<string>();
+    const postoSet = new Set<string>();
+    const cursoSet = new Set<string>();
+    const turmaSet = new Set<string>();
+
+    this.allCapacitacaos.forEach(c => {
+      if (c.militar?.nomeGuerra) {
+        nomeSet.add(c.militar.nomeGuerra);
+      }
+      if (c.militar?.posto?.postoSigla) {
+        postoSet.add(c.militar.posto.postoSigla);
+      }
+      if (c.turma?.curso?.cursoSigla) {
+        cursoSet.add(c.turma.curso.cursoSigla);
+      }
+      if (c.turma?.numeroBca) {
+        turmaSet.add(c.turma.numeroBca);
+      }
+    });
+
+    this.nomeGuerraOptions = Array.from(nomeSet).sort();
+    this.postoOptions = Array.from(postoSet).sort();
+    this.cursoSiglaOptions = Array.from(cursoSet).sort();
+    this.turmaOptions = Array.from(turmaSet).sort();
   }
 
   applyAdvancedFilters(): void {
@@ -286,6 +320,7 @@ export class CapacitacaoComponent implements OnInit {
         (!f.termino || (c.turma?.termino && c.turma.termino.format('YYYY-MM-DD') <= f.termino))
       );
     });
+    this.totalItems = this.capacitacaos.length;
   }
 
   clearAdvancedFilters(): void {
@@ -301,6 +336,7 @@ export class CapacitacaoComponent implements OnInit {
       capacitacaoStatus: ''
     };
     this.capacitacaos = this.allCapacitacaos.slice();
+    this.totalItems = this.capacitacaos.length;
   }
 
   protected handleNavigation(page: number, sortState: SortState, filterOptions?: IFilterOption[], currentSearch?: string): void {


### PR DESCRIPTION
## Summary
- provide dropdowns for advanced filter fields
- populate filter options from available `Capacitacao` data
- update item count after filtering

## Testing
- `npm test` *(fails: Cannot find package 'globals', needs internet)*

------
https://chatgpt.com/codex/tasks/task_e_685376640338832b8496406fc856ca33