### PR TITLE
Add course filter link integration

### DIFF
--- a/src/main/webapp/app/entities/capacitacao/list/capacitacao.component.ts
+++ b/src/main/webapp/app/entities/capacitacao/list/capacitacao.component.ts
@@ -109,6 +109,11 @@ export class CapacitacaoComponent implements OnInit {
         this.statusFilter = params['status'];
         this.search(this.statusFilter!); // Executa a busca com o status filtrado
       }
+
+      if (params['turma']) {
+        this.showAdvanced = true;
+        this.advancedFilters.turma = params['turma'];
+      }
     });
 
     // Carrega todos os Postos para mapear a prioridade e ordenar o filtro
@@ -131,7 +136,7 @@ export class CapacitacaoComponent implements OnInit {
       )
       .subscribe();
 
-    this.loadAllCapacitacaos();
+    this.loadAllCapacitacaos(true);
 
     this.filters.filterChanges.subscribe(filterOptions => this.handleNavigation(1, this.sortState(), filterOptions));
   }
@@ -368,7 +373,7 @@ export class CapacitacaoComponent implements OnInit {
     return this.capacitacaoService.query(queryObject).pipe(tap(() => (this.isLoading = false)));
   }
 
-  loadAllCapacitacaos(): void {
+  loadAllCapacitacaos(applyFilterAfterLoad: boolean = false): void {
     this.capacitacaoService.queryAll({ eagerload: true }).subscribe(res => {
       this.allCapacitacaos = res.body ?? [];
       this.updateFilterOptions();
@@ -377,6 +382,9 @@ export class CapacitacaoComponent implements OnInit {
       this.page = 1;
       this.totalItems = this.allCapacitacaos.length;
       this.updatePageData();
+      if (applyFilterAfterLoad && this.advancedFilters.turma) {
+        this.applyAdvancedFilters();
+      }
     });
   }
 

--- a/src/main/webapp/app/layouts/dashboard/dashboard.component.html
+++ b/src/main/webapp/app/layouts/dashboard/dashboard.component.html
@@ -137,7 +137,7 @@
                           <span class="text">
                             <a 
                                 [routerLink]="['/capacitacao']" 
-                                [queryParams]="{ status: capacitacao.turma?.id }"
+                                [queryParams]="{ turma: capacitacao.turma?.curso?.cursoNome }"
                                 routerLinkActive="active"
                                 [routerLinkActiveOptions]="{ exact: true }"
                                 class="small-box-footer link-dark link-underline-opacity-0 link-underline-opacity-50-hover"
@@ -191,7 +191,7 @@
                           <span class="text">
                             <a
                                 [routerLink]="['/capacitacao']"
-                                [queryParams]="{ status: capacitacao.turma?.id }"
+                                [queryParams]="{ turma: capacitacao.turma?.curso?.cursoNome }"
                                 routerLinkActive="active"
                                 [routerLinkActiveOptions]="{ exact: true }"
                                 class="small-box-footer link-dark link-underline-opacity-0 link-underline-opacity-50-hover"


### PR DESCRIPTION
## Summary
- update dashboard links to set `turma` query param
- read `turma` from query params in `CapacitacaoComponent`
- apply advanced filter automatically when navigated with a course

## Testing
- `./mvnw -q test` *(fails: Failed to fetch)*
- `./npmw test` *(fails: Cannot find package 'globals')*

------
https://chatgpt.com/codex/tasks/task_e_6855872526a0832b8e4f1423d79ceaa9