### PR TITLE
Fix dashboard turma filter persistence

### DIFF
--- a/src/main/webapp/app/entities/capacitacao/list/capacitacao.component.ts
+++ b/src/main/webapp/app/entities/capacitacao/list/capacitacao.component.ts
@@ -103,6 +103,8 @@ export class CapacitacaoComponent implements OnInit {
   }
 
   ngOnInit(): void {
+    const queryParams = this.activatedRoute.snapshot.queryParamMap;
+    const skipInitialLoad = queryParams.has('turma') || queryParams.has('ano');
 
     this.activatedRoute.queryParams.subscribe((params: any) => {
       if (params['status']) {
@@ -113,6 +115,11 @@ export class CapacitacaoComponent implements OnInit {
       if (params['turma']) {
         this.showAdvanced = true;
         this.advancedFilters.turma = params['turma'];
+      }
+
+      if (params['ano']) {
+        this.showAdvanced = true;
+        this.advancedFilters.ano = params['ano'];
       }
     });
 
@@ -131,8 +138,14 @@ export class CapacitacaoComponent implements OnInit {
 
     this.subscription = combineLatest([this.activatedRoute.queryParamMap, this.activatedRoute.data])
       .pipe(
-        tap(([params, data]) => { this.fillComponentAttributeFromRoute(params, data); }),
-        tap(() => { this.load(); }),
+        tap(([params, data]) => {
+          this.fillComponentAttributeFromRoute(params, data);
+        }),
+        tap(() => {
+          if (!skipInitialLoad) {
+            this.load();
+          }
+        }),
       )
       .subscribe();
 
@@ -382,7 +395,7 @@ export class CapacitacaoComponent implements OnInit {
       this.page = 1;
       this.totalItems = this.allCapacitacaos.length;
       this.updatePageData();
-      if (applyFilterAfterLoad && this.advancedFilters.turma) {
+      if (applyFilterAfterLoad && (this.advancedFilters.turma || this.advancedFilters.ano)) {
         this.applyAdvancedFilters();
       }
     });

--- a/src/main/webapp/app/layouts/dashboard/dashboard.component.html
+++ b/src/main/webapp/app/layouts/dashboard/dashboard.component.html
@@ -137,7 +137,7 @@
                           <span class="text">
                             <a 
                                 [routerLink]="['/capacitacao']" 
-                                [queryParams]="{ turma: capacitacao.turma?.curso?.cursoNome }"
+                                [queryParams]="{ turma: capacitacao.turma?.curso?.cursoNome, ano: capacitacao.turma?.ano }"
                                 routerLinkActive="active"
                                 [routerLinkActiveOptions]="{ exact: true }"
                                 class="small-box-footer link-dark link-underline-opacity-0 link-underline-opacity-50-hover"
@@ -191,7 +191,7 @@
                           <span class="text">
                             <a
                                 [routerLink]="['/capacitacao']"
-                                [queryParams]="{ turma: capacitacao.turma?.curso?.cursoNome }"
+                                [queryParams]="{ turma: capacitacao.turma?.curso?.cursoNome, ano: capacitacao.turma?.ano }"
                                 routerLinkActive="active"
                                 [routerLinkActiveOptions]="{ exact: true }"
                                 class="small-box-footer link-dark link-underline-opacity-0 link-underline-opacity-50-hover"


### PR DESCRIPTION
## Summary
- persist advanced turma filters when navigating from dashboard
- send turma year from dashboard

## Testing
- `npm test` *(fails: Cannot find package 'globals' due to offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_685593e47910832b80237d58eed13f36