### PR TITLE
Fix status filter navigation

### DIFF
--- a/src/main/webapp/app/entities/capacitacao/list/capacitacao.component.ts
+++ b/src/main/webapp/app/entities/capacitacao/list/capacitacao.component.ts
@@ -108,8 +108,8 @@ export class CapacitacaoComponent implements OnInit {
 
     this.activatedRoute.queryParams.subscribe((params: any) => {
       if (params['status']) {
-        this.statusFilter = params['status'];
-        this.search(this.statusFilter!); // Executa a busca com o status filtrado
+        this.showAdvanced = true;
+        this.advancedFilters.capacitacaoStatus = params['status'];
       }
 
       if (params['turma']) {
@@ -395,7 +395,10 @@ export class CapacitacaoComponent implements OnInit {
       this.page = 1;
       this.totalItems = this.allCapacitacaos.length;
       this.updatePageData();
-      if (applyFilterAfterLoad && (this.advancedFilters.turma || this.advancedFilters.ano)) {
+      if (
+        applyFilterAfterLoad &&
+        (this.advancedFilters.turma || this.advancedFilters.ano || this.advancedFilters.capacitacaoStatus)
+      ) {
         this.applyAdvancedFilters();
       }
     });


### PR DESCRIPTION
## Summary
- make Capacitacao component read status query param
- auto apply advanced filter when status param is set

## Testing
- `npm test` *(fails: Cannot find package 'globals')*

------
https://chatgpt.com/codex/tasks/task_e_6855a857149c832b87d7131cb822a508