### PR TITLE
Fix sorting for capacitacao list

### DIFF
--- a/src/main/webapp/app/entities/capacitacao/list/capacitacao.component.html
+++ b/src/main/webapp/app/entities/capacitacao/list/capacitacao.component.html
@@ -178,19 +178,19 @@
                 <fa-icon class="p-1" icon="sort"></fa-icon>
               </div>
             </th> -->
-            <th scope="col" jhiSortBy="inicio">
+            <th scope="col" jhiSortBy="turma.inicio">
               <div class="d-flex">
                 <span jhiTranslate="ecursosApp.turma.inicio">Inicio</span>
                 <fa-icon class="p-1" icon="sort"></fa-icon>
               </div>
             </th>
-            <th scope="col" jhiSortBy="termino">
+            <th scope="col" jhiSortBy="turma.termino">
               <div class="d-flex">
                 <span jhiTranslate="ecursosApp.turma.termino">Termino</span>
                 <fa-icon class="p-1" icon="sort"></fa-icon>
               </div>
             </th>
-            <th scope="col" jhiSortBy="ano">
+            <th scope="col" jhiSortBy="turma.ano">
               <div class="d-flex">
                 <span jhiTranslate="ecursosApp.turma.ano">Ano</span>
                 <fa-icon class="p-1" icon="sort"></fa-icon>
@@ -204,19 +204,19 @@
                 }
               </div>
             </th>
-            <th scope="col" jhiSortBy="numeroBca">
+            <th scope="col" jhiSortBy="turma.numeroBca">
               <div class="d-flex">
                 <span jhiTranslate="ecursosApp.turma.numeroBca">BCA</span>
                 <fa-icon class="p-1" icon="sort"></fa-icon>
               </div>
             </th>
-            <th scope="col" jhiSortBy="om">
+            <th scope="col" jhiSortBy="militar.om">
               <div class="d-flex">
                 <span jhiTranslate="ecursosApp.militar.om">Organização Militar</span>
                 <fa-icon class="p-1" icon="sort"></fa-icon>
               </div>
             </th>
-            <th scope="col" jhiSortBy="posto">
+            <th scope="col" jhiSortBy="militar.posto.postoSigla">
               <div class="d-flex">
                 <span jhiTranslate="ecursosApp.posto.detail.title">Posto</span>
                 <fa-icon class="p-1" icon="sort"></fa-icon>
@@ -228,25 +228,25 @@
                 <fa-icon class="p-1" icon="sort"></fa-icon>
               </div>
             </th>
-            <th scope="col" jhiSortBy="email">
+            <th scope="col" jhiSortBy="militar.email">
               <div class="d-flex">
                 <span jhiTranslate="ecursosApp.militar.email">email</span>
                 <fa-icon class="p-1" icon="sort"></fa-icon>
               </div>
             </th>
-            <th scope="col" jhiSortBy="tipo">
+            <th scope="col" jhiSortBy="turma.curso.tipo.categoria">
               <div class="d-flex">
                 <span jhiTranslate="ecursosApp.tipo.categoria">Tipo</span>
                 <fa-icon class="p-1" icon="sort"></fa-icon>
               </div>
             </th>
-            <th scope="col" jhiSortBy="turma">
+            <th scope="col" jhiSortBy="turma.curso.cursoNome">
               <div class="d-flex">
                 <span jhiTranslate="ecursosApp.capacitacao.turma">Turma</span>
                 <fa-icon class="p-1" icon="sort"></fa-icon>
               </div>
             </th>
-            <th scope="col" jhiSortBy="cursoSigla">
+            <th scope="col" jhiSortBy="turma.curso.cursoSigla">
               <div class="d-flex">
                 <span jhiTranslate="ecursosApp.curso.cursoSigla">cursoSigla</span>
                 <fa-icon class="p-1" icon="sort"></fa-icon>


### PR DESCRIPTION
## Summary
- map sort headers to nested entity fields so sorting works

## Testing
- `./mvnw -q verify` *(fails: Failed to fetch https://repo.maven.apache.org/...)*
- `./npmw test --silent` *(fails: Cannot find package 'globals' ...)*

------
https://chatgpt.com/codex/tasks/task_e_6855f9e69048832bb93852382bbb339c